### PR TITLE
Fix error dependabot

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -15,9 +15,8 @@ update_configs:
       - match:
           dependency_name: "*testing-library*"
       - match:
-          update_type:
-            - "semver:patch"
-            # - "security:patch"
-            # - "semver:minor"
-            # - "in_range"
-            # - "all"
+          update_type: "semver:patch"
+          # - "security:patch"
+          # - "semver:minor"
+          # - "in_range"
+          # - "all"

--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -16,7 +16,7 @@ update_configs:
           dependency_name: "*testing-library*"
       - match:
           update_type: "semver:patch"
-          # - "security:patch"
-          # - "semver:minor"
-          # - "in_range"
-          # - "all"
+          # "security:patch"
+          # "semver:minor"
+          # "in_range"
+          # "all"


### PR DESCRIPTION
```
Dependabot encountered the following error when parsing your .dependabot/config.yml:

The property '#/update_configs/0/automerged_updates/4/match/update_type' of type array did not match the following type: string
The property '#/update_configs/0/automerged_updates/4/match/update_type' value ["semver:patch"] did not match one of the following values: all, security:patch, semver:patch, semver:minor, in_range
```