### PR TITLE
Fix late percent overflow on circle skin mode

### DIFF
--- a/renderer/components/molecules/AgendaSkinCircle.tsx
+++ b/renderer/components/molecules/AgendaSkinCircle.tsx
@@ -130,12 +130,15 @@ export const AgendaSkinCircle: React.FC<Props> = ({
   const pastPercent = (pastSecond / totalSecond) * 100
   const pastDeadLinePercent = Math.min(pastPercent, nextProgressPercent)
 
-  const curentLatePercent = Math.min(
-    100,
-    (Math.max(0, lapSeconds[index - 1] - progressSeconds[index - 1]) /
-      agendaSecond) *
-      100,
-  )
+  const curentLatePercent =
+    index <= 0
+      ? 0
+      : Math.min(
+          100,
+          (Math.max(0, lapSeconds[index - 1] - progressSeconds[index - 1]) /
+            agendaSecond) *
+            100,
+        )
 
   const refRoot = React.useRef<HTMLDivElement>(null)
   const [shortSideSize, setShortSideSize] = React.useState(0)


### PR DESCRIPTION
Fix NaN bug by overflow array on first agenda

<img width="272" alt="スクリーンショット 2020-08-14 10 46 51" src="https://user-images.githubusercontent.com/3187220/90203374-7f554780-de1b-11ea-8271-81a1299561ad.png">
