### PR TITLE
Remove @type/node for prevent to conflict electron

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,6 @@
     "@testing-library/react": "10.4.9",
     "@testing-library/react-hooks": "3.4.1",
     "@types/jest": "26.0.10",
-    "@types/node": "12.12.54",
     "@types/papaparse": "5.0.6",
     "@types/react": "16.9.46",
     "@types/react-dom": "16.9.8",


### PR DESCRIPTION
Closes #145 

Related https://github.com/electron/electron/issues/21612

> https://www.electronjs.org/blog/typescript
> If you were already using third-party definitions like @types/electron and @types/node, you should remove them from your Electron project to prevent any collisions.