### PR TITLE
Disable global shortcut  temporarily

### DIFF
--- a/src/main/ipcs/shortcut.ts
+++ b/src/main/ipcs/shortcut.ts
@@ -5,25 +5,28 @@ interface DependencyInjection {
   globalShortcut: GlobalShortcut
 }
 
-export const initialize: Initializer<DependencyInjection> =
-  ({ globalShortcut }) =>
-  (_, sender) => {
-    globalShortcut.registerAll(
-      ['CommandOrControl+P', 'CommandOrControl+Return'],
-      () => {
-        sender.send({ type: 'ipc/shortcutToggle' })
-      },
-    )
-    globalShortcut.registerAll(
-      ['CommandOrControl+J', 'CommandOrControl+Down', 'CommandOrControl+Right'],
-      () => {
-        sender.send({ type: 'ipc/shortcutLap' })
-      },
-    )
-    globalShortcut.registerAll(
-      ['CommandOrControl+K', 'CommandOrControl+Up', 'CommandOrControl+Left'],
-      () => {
-        sender.send({ type: 'ipc/shortcutUndo' })
-      },
-    )
-  }
+// NOTE: disable global shortcut temporarily for prevent conflict with other apps e.g. vscode Command+P
+// TODO: scrutinize key maps or implement key config
+// eslint-disable-next-line @typescript-eslint/no-empty-function
+export const initialize: Initializer<DependencyInjection> = () => () => {}
+// ({ globalShortcut }) =>
+// (_, sender) => {
+//   globalShortcut.registerAll(
+//     ['CommandOrControl+P', 'CommandOrControl+Return'],
+//     () => {
+//       sender.send({ type: 'ipc/shortcutToggle' })
+//     },
+//   )
+//   globalShortcut.registerAll(
+//     ['CommandOrControl+J', 'CommandOrControl+Down', 'CommandOrControl+Right'],
+//     () => {
+//       sender.send({ type: 'ipc/shortcutLap' })
+//     },
+//   )
+//   globalShortcut.registerAll(
+//     ['CommandOrControl+K', 'CommandOrControl+Up', 'CommandOrControl+Left'],
+//     () => {
+//       sender.send({ type: 'ipc/shortcutUndo' })
+//     },
+//   )
+// }


### PR DESCRIPTION
For prevent conflict with other apps.
If conflict shortcut then it disables effect at other apps.

e.g. `Command+P` on vscode

TODO: scrutinize key maps or implement key config