### PR TITLE
Fixed prevented clicking updater snackbar on windows

### DIFF
--- a/src/renderer/components/organisms/UpdaterSnackbar.tsx
+++ b/src/renderer/components/organisms/UpdaterSnackbar.tsx
@@ -6,6 +6,7 @@ import IconButton from '@mui/material/IconButton'
 import LinearProgress from '@mui/material/LinearProgress'
 import Alert from '@mui/material/Alert'
 import CloseIcon from '@mui/icons-material/Close'
+import { styled } from '@mui/material/styles'
 import { useTranslationWithKey } from '../../hooks/useTranslationWithKey'
 
 interface Props {
@@ -16,6 +17,10 @@ interface Props {
   onClose: () => void
   onRestart: () => void
 }
+
+const StyledAlert = styled(Alert)(() => ({
+  WebkitAppRegion: 'no-drag',
+}))
 
 export const UpdaterSnackbar: React.FC<Props> = ({
   className,
@@ -34,7 +39,7 @@ export const UpdaterSnackbar: React.FC<Props> = ({
       className={className}
       open={open}
       action={
-        <Alert
+        <StyledAlert
           severity="info"
           icon={false}
           onClose={onClose}
@@ -75,7 +80,7 @@ export const UpdaterSnackbar: React.FC<Props> = ({
             variant="determinate"
             value={percent}
           />
-        </Alert>
+        </StyledAlert>
       }
     />
   )


### PR DESCRIPTION
Closes #386 

Fixed the following bug only windows.

<img width="325" alt="Electron" src="https://user-images.githubusercontent.com/3187220/222921848-c9ddf0c0-eef4-4e36-bbe5-ab823275c215.png">

