### PR TITLE
Move clearing localStorage to afterEach for stable e2e on windows

### DIFF
--- a/e2e/index.e2e.ts
+++ b/e2e/index.e2e.ts
@@ -51,6 +51,12 @@ test('save settings', async () => {
   const agendaTime1 = window.getByTestId('AgendaTimer1Value')
   const totalTime = window.getByTestId('TotalTimerValue')
   const idealTime = window.getByTestId('IdealTimerValue')
+  // There is a time lag for the value to change on windows
+  await expect
+    .poll(() => agendaLabel0.innerText(), {
+      intervals: [...Array(20)].map((_, i) => i * 100),
+    })
+    .toBe('Test1')
   expect(await agendaLabel0.innerText()).toBe('Test1')
   expect(await agendaLabel1.innerText()).toBe('Test2')
   expect(await agendaTime0.innerText()).toBe('00:01:30')

--- a/e2e/index.e2e.ts
+++ b/e2e/index.e2e.ts
@@ -29,9 +29,13 @@ test.beforeEach(async () => {
         ? `release/mac/${productName}.app/Contents/MacOS/${productName}`
         : `release/win-unpacked/${productName}.exe`,
   })
-  await electronApp.evaluate(async (electron) => {
-    return electron.session.defaultSession.clearStorageData()
-  })
+  // clear localStorage
+  // NOTE: The following code is slow to clear storage data.
+  // await electronApp.evaluate(async (electron) => {
+  //   return electron.session.defaultSession.clearStorageData()
+  // })
+  const page = await electronApp.firstWindow()
+  await page.evaluate(() => window.localStorage.clear())
 })
 
 test.afterEach(async () => {
@@ -55,10 +59,6 @@ test('save settings', async () => {
   const agendaTime1 = window.getByTestId('AgendaTimer1Value')
   const totalTime = window.getByTestId('TotalTimerValue')
   const idealTime = window.getByTestId('IdealTimerValue')
-  // There is a time lag for the value to change on windows
-  await expect
-    .poll(() => agendaLabel0.innerText(), defaultPollingOptions)
-    .toBe('Test1')
   expect(await agendaLabel0.innerText()).toBe('Test1')
   expect(await agendaLabel1.innerText()).toBe('Test2')
   expect(await agendaTime0.innerText()).toBe('00:01:30')

--- a/e2e/index.e2e.ts
+++ b/e2e/index.e2e.ts
@@ -33,7 +33,7 @@ test.beforeEach(async () => {
 
 test.afterEach(async () => {
   // clear localStorage
-  // NOTE: The following code is slow to clear storage data.
+  // NOTE: The following code occurred hung up test on afterEach
   // await electronApp.evaluate(async (electron) => {
   //   return electron.session.defaultSession.clearStorageData()
   // })

--- a/e2e/index.e2e.ts
+++ b/e2e/index.e2e.ts
@@ -29,6 +29,9 @@ test.beforeEach(async () => {
         ? `release/mac/${productName}.app/Contents/MacOS/${productName}`
         : `release/win-unpacked/${productName}.exe`,
   })
+})
+
+test.afterEach(async () => {
   // clear localStorage
   // NOTE: The following code is slow to clear storage data.
   // await electronApp.evaluate(async (electron) => {
@@ -36,9 +39,6 @@ test.beforeEach(async () => {
   // })
   const page = await electronApp.firstWindow()
   await page.evaluate(() => window.localStorage.clear())
-})
-
-test.afterEach(async () => {
   await electronApp.close()
 })
 

--- a/e2e/index.e2e.ts
+++ b/e2e/index.e2e.ts
@@ -16,6 +16,10 @@ const captureScreenshot = async (window: Page, identifier: string) => {
   return window.screenshot({ path: filepath })
 }
 
+const defaultPollingOptions = {
+  intervals: [...Array(20)].map((_, i) => i * 100),
+}
+
 let electronApp: ElectronApplication
 
 test.beforeEach(async () => {
@@ -53,9 +57,7 @@ test('save settings', async () => {
   const idealTime = window.getByTestId('IdealTimerValue')
   // There is a time lag for the value to change on windows
   await expect
-    .poll(() => agendaLabel0.innerText(), {
-      intervals: [...Array(20)].map((_, i) => i * 100),
-    })
+    .poll(() => agendaLabel0.innerText(), defaultPollingOptions)
     .toBe('Test1')
   expect(await agendaLabel0.innerText()).toBe('Test1')
   expect(await agendaLabel1.innerText()).toBe('Test2')
@@ -144,9 +146,7 @@ test('behave agenda timer', async () => {
   await pauseIcon.waitFor({ state: 'visible' })
   await captureScreenshot(window, 'circle-played')
   await expect
-    .poll(() => agendaTime0.innerText(), {
-      intervals: [...Array(20)].map((_, i) => i * 100),
-    })
+    .poll(() => agendaTime0.innerText(), defaultPollingOptions)
     .toBe('00:00:59')
   await pauseIcon.click()
   await playIcon.waitFor({ state: 'visible' })
@@ -158,9 +158,7 @@ test('behave agenda timer', async () => {
   const lapIcon = window.getByTestId('LapIcon')
   await lapIcon.click()
   await expect
-    .poll(() => agendaTime1.innerText(), {
-      intervals: [...Array(20)].map((_, i) => i * 100),
-    })
+    .poll(() => agendaTime1.innerText(), defaultPollingOptions)
     .toBe('00:02:59')
   await pauseIcon.click()
   expect(await agendaTime0.isVisible()).toBe(false)
@@ -200,9 +198,7 @@ test('behave agenda timer using circle skin', async () => {
   await playIcon.click()
   await captureScreenshot(window, 'circle-played')
   await expect
-    .poll(() => agendaTime.innerText(), {
-      intervals: [...Array(20)].map((_, i) => i * 100),
-    })
+    .poll(() => agendaTime.innerText(), defaultPollingOptions)
     .toBe('00:00:59')
   const pauseIcon = window.getByTestId('PauseIcon')
   await pauseIcon.click()
@@ -214,9 +210,7 @@ test('behave agenda timer using circle skin', async () => {
   const lapIcon = window.getByTestId('LapIcon')
   await lapIcon.click()
   await expect
-    .poll(() => agendaTime.innerText(), {
-      intervals: [...Array(20)].map((_, i) => i * 100),
-    })
+    .poll(() => agendaTime.innerText(), defaultPollingOptions)
     .toBe('00:02:59')
   expect(await totalTime.innerText()).toBe('00:03:58')
   expect(await idealTime.innerText()).toBe('00:03:58')


### PR DESCRIPTION
Fail e2e test sometimes cause of delay in clearing localStorage.

https://github.com/namikingsoft/interv-timer/actions/runs/4398765846/jobs/7702842861#step:9:35
https://github.com/namikingsoft/interv-timer/actions/runs/4355938416/jobs/7613242301#step:9:36