### PR TITLE
Drag frameless window via IPC instead of -webkit-app-region

### DIFF
--- a/src/main/ipcs/dragWindow.ts
+++ b/src/main/ipcs/dragWindow.ts
@@ -1,0 +1,20 @@
+import { BrowserWindow, Screen } from 'electron'
+import { Initializer } from './type'
+
+interface DependencyInjection {
+  screen: Screen
+  win: BrowserWindow
+}
+
+export const initialize: Initializer<DependencyInjection> =
+  ({ screen, win }) =>
+  (receiver) => {
+    receiver.on((action) => {
+      switch (action.type) {
+        case 'ipc/dragWindow': {
+          const { x, y } = screen.getCursorScreenPoint()
+          win.setPosition(x - action.payload.startX, y - action.payload.startY)
+        }
+      }
+    })
+  }

--- a/src/main/ipcs/index.ts
+++ b/src/main/ipcs/index.ts
@@ -1,9 +1,10 @@
-import { BrowserWindow, ipcMain, globalShortcut, app } from 'electron'
+import { BrowserWindow, ipcMain, globalShortcut, app, screen } from 'electron'
 import { autoUpdater } from 'electron-updater'
 import log from 'electron-log'
 import * as appIpc from './app'
-import * as shortcut from './shortcut'
 import * as updater from './updater'
+import * as dragWindow from './dragWindow'
+import * as shortcut from './shortcut'
 
 const channelName = 'ipcAction'
 
@@ -23,5 +24,6 @@ export const initialize = (win: BrowserWindow, isProd: boolean): void => {
 
   appIpc.initialize({ app, win })(receiver, sender)
   updater.initialize({ autoUpdater, isProd })(receiver, sender)
+  dragWindow.initialize({ screen, win })(receiver, sender)
   shortcut.initialize({ globalShortcut })(receiver, sender)
 }

--- a/src/renderer/components/atoms/AppLayout.tsx
+++ b/src/renderer/components/atoms/AppLayout.tsx
@@ -4,18 +4,13 @@ import Container from '@mui/material/Container'
 
 const textBorderColor = '#333'
 
-interface IsDragRegionProps {
-  isDragRegion?: boolean
-}
-
-const ContainerDiv = styled('div')<IsDragRegionProps>(({ isDragRegion }) => ({
+const ContainerDiv = styled('div')(() => ({
   display: 'flex',
   flexFlow: 'column nowrap',
   width: '100%',
   height: '100%',
   color: 'white',
   textShadow: `${textBorderColor} 1px 1px 0, ${textBorderColor} -1px -1px 0, ${textBorderColor} -1px 1px 0, ${textBorderColor} 1px -1px 0, ${textBorderColor} 0px 1px 0, ${textBorderColor}  0 -1px 0, ${textBorderColor} -1px 0 0, ${textBorderColor} 1px 0 0`,
-  WebkitAppRegion: isDragRegion ? 'drag' : undefined,
 }))
 
 const Nav = styled('nav')(() => ({
@@ -23,10 +18,6 @@ const Nav = styled('nav')(() => ({
   display: 'flex',
   flexFlow: 'row nowrap',
   justifyContent: 'space-between',
-  WebkitAppRegion: 'drag',
-  '& button': {
-    WebkitAppRegion: 'no-drag',
-  },
   // Icon
   '& svg': {
     filter: 'drop-shadow(0px 0px 1.5px black);',
@@ -63,7 +54,6 @@ interface Props {
   body: React.ReactNode
   footer?: React.ReactNode
   onDoubleClick?: () => void
-  isDragRegion?: boolean
 }
 
 export const AppLayout: React.FC<Props> = ({
@@ -73,14 +63,9 @@ export const AppLayout: React.FC<Props> = ({
   body,
   footer,
   onDoubleClick,
-  isDragRegion,
 }) => {
   return (
-    <ContainerDiv
-      className={className}
-      onDoubleClick={onDoubleClick}
-      isDragRegion={isDragRegion}
-    >
+    <ContainerDiv className={className} onDoubleClick={onDoubleClick}>
       <Nav>
         <NavLeftDiv>{nav}</NavLeftDiv>
         <NavRightDiv>{navRight}</NavRightDiv>

--- a/src/renderer/components/organisms/UpdaterSnackbar.tsx
+++ b/src/renderer/components/organisms/UpdaterSnackbar.tsx
@@ -6,7 +6,6 @@ import IconButton from '@mui/material/IconButton'
 import LinearProgress from '@mui/material/LinearProgress'
 import Alert from '@mui/material/Alert'
 import CloseIcon from '@mui/icons-material/Close'
-import { styled } from '@mui/material/styles'
 import { useTranslationWithKey } from '../../hooks/useTranslationWithKey'
 
 interface Props {
@@ -17,10 +16,6 @@ interface Props {
   onClose: () => void
   onRestart: () => void
 }
-
-const StyledAlert = styled(Alert)(() => ({
-  WebkitAppRegion: 'no-drag',
-}))
 
 export const UpdaterSnackbar: React.FC<Props> = ({
   className,
@@ -39,7 +34,7 @@ export const UpdaterSnackbar: React.FC<Props> = ({
       className={className}
       open={open}
       action={
-        <StyledAlert
+        <Alert
           severity="info"
           icon={false}
           onClose={onClose}
@@ -80,7 +75,7 @@ export const UpdaterSnackbar: React.FC<Props> = ({
             variant="determinate"
             value={percent}
           />
-        </StyledAlert>
+        </Alert>
       }
     />
   )

--- a/src/renderer/components/templates/AppFrame.tsx
+++ b/src/renderer/components/templates/AppFrame.tsx
@@ -4,6 +4,7 @@ import DragIndicatorIcon from '@mui/icons-material/DragIndicator'
 import CloseIcon from '@mui/icons-material/Close'
 import { UpdaterSnackbar } from '../organisms/UpdaterSnackbar'
 import { useSelector, useDispatch } from '../../hooks/redux'
+import { useDragWindow } from '../../hooks/useDragWindow'
 
 interface Props {
   className?: string
@@ -110,6 +111,8 @@ export const AppFrame: React.FC<Props> = ({ className, children }) => {
   }, [dispatch])
 
   const showHeader = isHover
+
+  useDragWindow()
 
   return (
     <ContainerDiv

--- a/src/renderer/components/templates/AppFrame.tsx
+++ b/src/renderer/components/templates/AppFrame.tsx
@@ -20,9 +20,6 @@ const ContainerDiv = styled('div')(() => ({
   bottom: 0,
   overflow: 'hidden',
   borderRadius: `${radiusSize}px`,
-  // if apply this whole then do not receive mouse events on windows
-  // refs. https://stackoverflow.com/questions/56338939/hover-in-css-is-not-working-with-electron
-  // WebkitAppRegion: 'drag',
 }))
 
 const HeaderDiv = styled('div')(() => ({
@@ -45,7 +42,6 @@ const HeaderDiv = styled('div')(() => ({
 const DragAreaDiv = styled('div')(() => ({
   flex: '1 0 auto',
   userSelect: 'none',
-  WebkitAppRegion: 'drag',
   // TODO: no effect on windows, because do not receive mouse events
   // refs. https://stackoverflow.com/questions/56338939/hover-in-css-is-not-working-with-electron
   cursor: 'move',
@@ -113,8 +109,7 @@ export const AppFrame: React.FC<Props> = ({ className, children }) => {
     dispatch({ type: 'ipc/quit' })
   }, [dispatch])
 
-  // NOTE: windows does not accept mouse event on drag region
-  const showHeader = isHover || window.platform !== 'darwin'
+  const showHeader = isHover
 
   return (
     <ContainerDiv

--- a/src/renderer/hooks/useDragWindow.ts
+++ b/src/renderer/hooks/useDragWindow.ts
@@ -1,0 +1,39 @@
+import React from 'react'
+import { useDispatch } from './redux'
+
+// refs. https://github.com/electron/electron/issues/1354#issuecomment-1066341381
+export const useDragWindow = () => {
+  const dispatch = useDispatch()
+
+  const refMouseX = React.useRef(0)
+  const refMouseY = React.useRef(0)
+  const refAnimationId = React.useRef(0)
+
+  const sendIpc = React.useCallback(() => {
+    dispatch({
+      type: 'ipc/dragWindow',
+      payload: { startX: refMouseX.current, startY: refMouseY.current },
+    })
+    refAnimationId.current = requestAnimationFrame(sendIpc)
+  }, [])
+
+  const onMouseUp = React.useCallback(() => {
+    document.removeEventListener('mouseup', onMouseUp)
+    cancelAnimationFrame(refAnimationId.current)
+  }, [])
+
+  const onMouseDown = React.useCallback((e: MouseEvent) => {
+    refMouseX.current = e.clientX
+    refMouseY.current = e.clientY
+
+    document.addEventListener('mouseup', onMouseUp)
+    refAnimationId.current = requestAnimationFrame(sendIpc)
+  }, [])
+
+  React.useEffect(() => {
+    document.addEventListener('mousedown', onMouseDown)
+    return () => {
+      document.removeEventListener('mousedown', onMouseDown)
+    }
+  }, [])
+}

--- a/src/renderer/modules/ipc/epic.ts
+++ b/src/renderer/modules/ipc/epic.ts
@@ -1,6 +1,6 @@
 import { Epic, ofType } from 'redux-observable'
 import { Subject } from 'rxjs'
-import { tap, map } from 'rxjs/operators'
+import { tap, map, ignoreElements } from 'rxjs/operators'
 import { Action, AppInitAction, NoopAction } from '../type'
 import {
   SetVisibleOnAllWorkspaces,
@@ -23,23 +23,24 @@ export const initialize: Epic<Action, NoopAction> = (action$) =>
     map(() => ({ type: 'noop' })),
   )
 
-export const send: Epic<Action, NoopAction> = (action$) =>
+export const send: Epic<Action> = (action$) =>
   action$.pipe(
     ofType<
       Action,
       | 'ipc/quit'
       | 'ipc/setVisibleOnAllWorkspaces'
+      | 'ipc/dragWindow'
       | 'ipc/updaterCheckForUpdates'
-      | 'ipc/updaterQuitAndInstall',
-      RequestAction
+      | 'ipc/updaterQuitAndInstall'
     >(
       'ipc/quit',
       'ipc/setVisibleOnAllWorkspaces',
+      'ipc/dragWindow',
       'ipc/updaterCheckForUpdates',
       'ipc/updaterQuitAndInstall',
     ),
-    tap((action) => api.send(action)),
-    map(() => ({ type: 'noop' })),
+    tap<RequestAction>((action) => api.send(action)),
+    ignoreElements(),
   )
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Epic<unknown>

--- a/src/renderer/modules/ipc/type.d.ts
+++ b/src/renderer/modules/ipc/type.d.ts
@@ -7,6 +7,14 @@ export interface SetVisibleOnAllWorkSpacesAction {
   payload: boolean
 }
 
+export interface DragWindowAction {
+  type: 'ipc/dragWindow'
+  payload: {
+    startX: number
+    startY: number
+  }
+}
+
 export interface ShortcutToggleAction {
   type: 'ipc/shortcutToggle'
 }
@@ -50,6 +58,7 @@ export interface UpdaterErrorAction {
 export type RequestAction =
   | QuitAction
   | SetVisibleOnAllWorkSpacesAction
+  | DragWindowAction
   | ShortcutToggleAction
   | ShortcutLapAction
   | ShortcutUndoAction

--- a/src/renderer/modules/sound/epic.ts
+++ b/src/renderer/modules/sound/epic.ts
@@ -1,3 +1,4 @@
+import { of, NEVER } from 'rxjs'
 import { Epic, ofType } from 'redux-observable'
 import { tap, ignoreElements, mergeMap } from 'rxjs/operators'
 import { Action, State } from '../type'
@@ -5,7 +6,6 @@ import * as api from './api'
 import { roundSecond } from '../timer/util'
 import { hurrySecond } from '../timer/const'
 import { PlayHurryAction, PlayTimeupAction } from './type'
-import { of, NEVER } from 'rxjs'
 
 export const mapToPlayOnElapsedSecond: Epic<
   Action,

--- a/src/renderer/pages/home.tsx
+++ b/src/renderer/pages/home.tsx
@@ -74,10 +74,6 @@ const Home: React.FC = () => {
     if (finishedAll) dispatch({ type: 'timer/stop' })
   }, [finishedAll])
 
-  // For increase priority of step forwarding on double click at windows
-  // https://github.com/electron/electron/issues/1354
-  const enabledDragRegion = window.platform === 'darwin'
-
   return (
     <AppLayout
       nav={
@@ -161,7 +157,6 @@ const Home: React.FC = () => {
         </Grid>
       }
       onDoubleClick={onDoubleClickLayout}
-      isDragRegion={enabledDragRegion}
     />
   )
 }


### PR DESCRIPTION
Using IPC. refs. https://github.com/electron/electron/issues/1354#issuecomment-1066341381
instead of `-webkit-app-region: drag` style by the following breaking change of electron v23.

> ### Behavior Changed: Draggable Regions on macOS
> The implementation of draggable regions (using the CSS property -webkit-app-region: drag) has changed on macOS to bring it in line with Windows and Linux. Previously, when a region with -webkit-app-region: no-drag overlapped a region with -webkit-app-region: drag, the no-drag region would always take precedence on macOS, regardless of CSS layering. That is, if a drag region was above a no-drag region, it would be ignored. Beginning in Electron 23, a drag region on top of a no-drag region will correctly cause the region to be draggable.
>
> [Breaking Changes | Electron](https://www.electronjs.org/docs/latest/breaking-changes#behavior-changed-draggable-regions-on-macos)

This Pull Request will make WIndows and macOS behavior of frameless window match.
